### PR TITLE
Install everything in one pip command, to better handle dependency version resolution.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,17 @@ jobs:
             pip install --progress-bar=off -U pip
       - run:
           name: Install GPflow
-          command: |
-            source .venv/bin/activate
-            git clone --branch develop https://github.com/GPflow/GPflow.git
-            # Ensure consistency between tensorflow and tensorflow-probability
-            pip install --progress-bar=off tensorflow==2.6.* tensorflow-probability==0.14.*
-            pip install --progress-bar=off -e GPflow -r GPflow/tests_requirements.txt
+          command: "
+            source .venv/bin/activate \n
+            git clone --branch develop https://github.com/GPflow/GPflow.git \n
+            # Everything is installed in one pip command, to allow for better dependency version
+            # resolution. Explicit tensorflow and tensorflow-probability version, to ensure
+            # consistency between them. \n
+            pip install --progress-bar=off
+              -e GPflow
+              -r GPflow/tests_requirements.txt
+              tensorflow==2.6.* tensorflow-probability==0.14.* \n
+          "
       - run:
           name: Make notebooks and move docs
           no_output_timeout: 20m


### PR DESCRIPTION
Fixes https://github.com/GPflow/GPflow/issues/1758.

I believe the problem was:

1. We first install `tensorflow==2.6.*` and `tensorflow-probability==0.14.*`.
2. We then install the GPflow `test_requirements.txt`.
3. `test_requiremets.txt` requires `mypy`.
4. The newest version of `mypy` requires a newer version of `typing_extensions` than `tensorflow==2.6.*`.
5. Because `pip` isn't too smart, and they were installed with different commands `pip` tries to find a version of `tensorflow` that`s compatible with the newer `typing_extensions`.
6. It finds an ancient version of `tensorflow` that doesn't require `typing_extensions` at all.
7. Stuff blows up.

By installing everything at the same time `pip` can be a bit smarter, and instead resolves this by using a slightly older version of `mypy`.